### PR TITLE
Add mobile dropdown menu to header

### DIFF
--- a/code0828 4/index.html
+++ b/code0828 4/index.html
@@ -28,6 +28,22 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-area">
+  <button id="menuButton" class="menu-button" aria-label="Menu">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="3" y1="6" x2="21" y2="6" stroke-linecap="round"/>
+      <line x1="3" y1="12" x2="21" y2="12" stroke-linecap="round"/>
+      <line x1="3" y1="18" x2="21" y2="18" stroke-linecap="round"/>
+    </svg>
+  </button>
+  <div id="menuDropdown" class="menu-dropdown hidden">
+    <a href="index.html">Home</a>
+    <a href="rosters/rosters.html">Rosters</a>
+    <a href="ownership/ownership.html">Ownership</a>
+    <a href="#">Coming Soon</a>
+    <a href="#">Coming Soon</a>
+  </div>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/ownership/ownership.html
+++ b/code0828 4/ownership/ownership.html
@@ -28,6 +28,22 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-area">
+  <button id="menuButton" class="menu-button" aria-label="Menu">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="3" y1="6" x2="21" y2="6" stroke-linecap="round"/>
+      <line x1="3" y1="12" x2="21" y2="12" stroke-linecap="round"/>
+      <line x1="3" y1="18" x2="21" y2="18" stroke-linecap="round"/>
+    </svg>
+  </button>
+  <div id="menuDropdown" class="menu-dropdown hidden">
+    <a href="../index.html">Home</a>
+    <a href="../rosters/rosters.html">Rosters</a>
+    <a href="ownership.html">Ownership</a>
+    <a href="#">Coming Soon</a>
+    <a href="#">Coming Soon</a>
+  </div>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/rosters/rosters.html
+++ b/code0828 4/rosters/rosters.html
@@ -28,6 +28,22 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-area">
+  <button id="menuButton" class="menu-button" aria-label="Menu">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <line x1="3" y1="6" x2="21" y2="6" stroke-linecap="round"/>
+      <line x1="3" y1="12" x2="21" y2="12" stroke-linecap="round"/>
+      <line x1="3" y1="18" x2="21" y2="18" stroke-linecap="round"/>
+    </svg>
+  </button>
+  <div id="menuDropdown" class="menu-dropdown hidden">
+    <a href="../index.html">Home</a>
+    <a href="rosters.html">Rosters</a>
+    <a href="../ownership/ownership.html">Ownership</a>
+    <a href="#">Coming Soon</a>
+    <a href="#">Coming Soon</a>
+  </div>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/scripts/app.js
+++ b/code0828 4/scripts/app.js
@@ -25,6 +25,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
+        const menuButton = document.getElementById('menuButton');
+        const menuDropdown = document.getElementById('menuDropdown');
         const pageType = document.body.dataset.page || 'welcome';
 
         // --- State ---
@@ -90,6 +92,16 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
         depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
         positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
+
+        menuButton?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            menuDropdown?.classList.toggle('hidden');
+        });
+        document.addEventListener('click', (e) => {
+            if (!menuDropdown?.contains(e.target) && e.target !== menuButton) {
+                menuDropdown?.classList.add('hidden');
+            }
+        });
         
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {

--- a/code0828 4/styles/styles.css
+++ b/code0828 4/styles/styles.css
@@ -240,8 +240,54 @@
         .username-area {
             flex-grow: 1;
             min-width: 120px; /* prevent it from getting too small */
-            max-width: 150px;
+            max-width: 135px;
             padding: .3rem;
+        }
+        .menu-area {
+            position: relative;
+            padding: .3rem;
+        }
+        .menu-button {
+            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
+            border: 1px solid var(--color-panel-border);
+            border-radius: 8px;
+            -webkit-backdrop-filter: blur(4px) saturate(110%);
+            backdrop-filter: blur(4px) saturate(110%);
+            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+            padding: 0.3rem;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            color: var(--color-text-secondary);
+        }
+        .menu-button svg {
+            width: 16px;
+            height: 16px;
+        }
+        .menu-dropdown {
+            position: absolute;
+            top: calc(100% + 0.25rem);
+            left: 0;
+            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
+            border: 1px solid var(--color-panel-border);
+            border-radius: 8px;
+            -webkit-backdrop-filter: blur(4px) saturate(110%);
+            backdrop-filter: blur(4px) saturate(110%);
+            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+            display: flex;
+            flex-direction: column;
+            min-width: 140px;
+            z-index: 20;
+        }
+        .menu-dropdown a {
+            padding: 0.35rem 0.75rem;
+            color: var(--color-text-secondary);
+            text-decoration: none;
+            white-space: nowrap;
+        }
+        .menu-dropdown a:hover {
+            color: var(--color-text-primary);
+            background: rgba(115,0,255,0.15);
         }
         /* Replace existing #usernameInput block with this */
 #usernameInput {


### PR DESCRIPTION
## Summary
- add compact menu icon and dropdown to header on all pages
- adjust username input width and styles for mobile layout
- handle dropdown open/close logic in app.js

## Testing
- `npm test` *(fails: ENOENT package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cc9d0b64832e8c9279fb809bd4f8