### PR TITLE
Add mobile header menu

### DIFF
--- a/code0828 4/index.html
+++ b/code0828 4/index.html
@@ -28,6 +28,20 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-wrapper">
+  <button id="menuToggle" class="menu-button" aria-label="Menu">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M3 6h18M3 12h18M3 18h18" />
+    </svg>
+  </button>
+  <nav id="dropdownMenu" class="dropdown-menu hidden">
+    <a href="index.html">Home</a>
+    <a href="rosters/rosters.html">Rosters</a>
+    <a href="ownership/ownership.html">Ownership %</a>
+    <a href="#">Option 4</a>
+    <a href="#">Option 5</a>
+  </nav>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/ownership/ownership.html
+++ b/code0828 4/ownership/ownership.html
@@ -28,6 +28,20 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-wrapper">
+  <button id="menuToggle" class="menu-button" aria-label="Menu">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M3 6h18M3 12h18M3 18h18" />
+    </svg>
+  </button>
+  <nav id="dropdownMenu" class="dropdown-menu hidden">
+    <a href="../index.html">Home</a>
+    <a href="../rosters/rosters.html">Rosters</a>
+    <a href="ownership.html">Ownership %</a>
+    <a href="#">Option 4</a>
+    <a href="#">Option 5</a>
+  </nav>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/rosters/rosters.html
+++ b/code0828 4/rosters/rosters.html
@@ -28,6 +28,20 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-wrapper">
+  <button id="menuToggle" class="menu-button" aria-label="Menu">
+    <svg viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2">
+      <path d="M3 6h18M3 12h18M3 18h18" />
+    </svg>
+  </button>
+  <nav id="dropdownMenu" class="dropdown-menu hidden">
+    <a href="../index.html">Home</a>
+    <a href="rosters.html">Rosters</a>
+    <a href="../ownership/ownership.html">Ownership %</a>
+    <a href="#">Option 4</a>
+    <a href="#">Option 5</a>
+  </nav>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/scripts/app.js
+++ b/code0828 4/scripts/app.js
@@ -25,6 +25,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
+        const dropdownMenu = document.getElementById('dropdownMenu');
+        const menuToggle = document.getElementById('menuToggle');
         const pageType = document.body.dataset.page || 'welcome';
 
         // --- State ---
@@ -90,6 +92,13 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
         depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
         positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
+
+        menuToggle?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            dropdownMenu?.classList.toggle('hidden');
+        });
+        dropdownMenu?.addEventListener('click', (e) => e.stopPropagation());
+        document.addEventListener('click', () => dropdownMenu?.classList.add('hidden'));
         
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {

--- a/code0828 4/styles/styles.css
+++ b/code0828 4/styles/styles.css
@@ -218,6 +218,49 @@
             overflow-x: auto; /* Allow horizontal scrolling if needed */
             padding-bottom: 2px; /* space for scrollbar */
         }
+
+        /* Menu icon + dropdown */
+        .menu-wrapper {
+            position: relative;
+            flex: 0 0 auto;
+        }
+        .menu-button {
+            background: transparent;
+            border: none;
+            padding: 0.25rem;
+            cursor: pointer;
+        }
+        .menu-button svg {
+            width: 16px;
+            height: 16px;
+            stroke: var(--color-text-primary);
+        }
+        .dropdown-menu {
+            position: absolute;
+            top: 100%;
+            left: 0;
+            background: var(--color-panel-bg);
+            border: 1px solid var(--color-panel-border);
+            border-radius: 8px;
+            margin-top: 0.25rem;
+            display: flex;
+            flex-direction: column;
+            min-width: 120px;
+            z-index: 1000;
+        }
+        .dropdown-menu.hidden {
+            display: none;
+        }
+        .dropdown-menu a {
+            padding: 0.25rem 0.5rem;
+            text-decoration: none;
+            color: var(--color-text-primary);
+            font-size: 0.7rem;
+            white-space: nowrap;
+        }
+        .dropdown-menu a:hover {
+            background: rgba(255,255,255,0.05);
+        }
         .header-row:nth-child(2), .header-row:nth-child(3) {
             border-top: 1px solid var(--color-panel-border);
             padding-top: 0.25rem;
@@ -239,8 +282,8 @@
         /* Row 1 */
         .username-area {
             flex-grow: 1;
-            min-width: 120px; /* prevent it from getting too small */
-            max-width: 150px;
+            min-width: 100px; /* slightly smaller to fit menu icon */
+            max-width: 120px;
             padding: .3rem;
         }
         /* Replace existing #usernameInput block with this */


### PR DESCRIPTION
## Summary
- Add compact menu icon and dropdown navigation to headers on all pages
- Shrink username input to keep header elements on one line on mobile
- Implement JavaScript to toggle the dropdown menu

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cc9d0b64832e8c9279fb809bd4f8