### PR TITLE
Add mobile dropdown menu to header

### DIFF
--- a/code0828 4/index.html
+++ b/code0828 4/index.html
@@ -28,6 +28,16 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-wrapper">
+<button id="menuButton" class="menu-button" aria-label="Menu">☰</button>
+<div id="menuDropdown" class="menu-dropdown hidden">
+<a href="index.html">Home</a>
+<a href="rosters/rosters.html">Rosters</a>
+<a href="ownership/ownership.html">Ownership</a>
+<a href="#">Placeholder</a>
+<a href="#">Placeholder</a>
+</div>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/ownership/ownership.html
+++ b/code0828 4/ownership/ownership.html
@@ -28,6 +28,16 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-wrapper">
+<button id="menuButton" class="menu-button" aria-label="Menu">☰</button>
+<div id="menuDropdown" class="menu-dropdown hidden">
+<a href="../index.html">Home</a>
+<a href="../rosters/rosters.html">Rosters</a>
+<a href="ownership.html">Ownership</a>
+<a href="#">Placeholder</a>
+<a href="#">Placeholder</a>
+</div>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/rosters/rosters.html
+++ b/code0828 4/rosters/rosters.html
@@ -28,6 +28,16 @@
 <div id="header-container">
 <header class="app-header glass-panel">
 <div class="header-row">
+<div class="menu-wrapper">
+<button id="menuButton" class="menu-button" aria-label="Menu">☰</button>
+<div id="menuDropdown" class="menu-dropdown hidden">
+<a href="../index.html">Home</a>
+<a href="rosters.html">Rosters</a>
+<a href="../ownership/ownership.html">Ownership</a>
+<a href="#">Placeholder</a>
+<a href="#">Placeholder</a>
+</div>
+</div>
 <div class="username-area">
 <input autocapitalize="none" autocomplete="username" autocorrect="off" id="usernameInput" inputmode="text" name="username" placeholder="SLPR Username..." type="text" value="The_Oracle"/>
 </div>

--- a/code0828 4/scripts/app.js
+++ b/code0828 4/scripts/app.js
@@ -25,6 +25,8 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         const positionalFiltersContainer = document.getElementById('positional-filters');
         const tradeSimulator = document.getElementById('tradeSimulator');
         const mainContent = document.getElementById('content');
+        const menuButton = document.getElementById('menuButton');
+        const menuDropdown = document.getElementById('menuDropdown');
         const pageType = document.body.dataset.page || 'welcome';
 
         // --- State ---
@@ -90,6 +92,18 @@ function showLegend(){ try{ document.getElementById('legend-section')?.classList
         positionalViewBtn?.addEventListener('click', () => setRosterView('positional'));
         depthChartViewBtn?.addEventListener('click', () => setRosterView('depth'));
         positionalFiltersContainer?.addEventListener('click', handlePositionFilter);
+
+        menuButton?.addEventListener('click', (e) => {
+            e.stopPropagation();
+            menuDropdown?.classList.toggle('hidden');
+        });
+
+        document.addEventListener('click', (e) => {
+            if (!menuDropdown || menuDropdown.classList.contains('hidden')) return;
+            if (!menuDropdown.contains(e.target) && e.target !== menuButton) {
+                menuDropdown.classList.add('hidden');
+            }
+        });
         
         // --- Initialization ---
         document.addEventListener('DOMContentLoaded', async () => {

--- a/code0828 4/styles/styles.css
+++ b/code0828 4/styles/styles.css
@@ -239,9 +239,64 @@
         /* Row 1 */
         .username-area {
             flex-grow: 1;
-            min-width: 120px; /* prevent it from getting too small */
-            max-width: 150px;
+            min-width: 110px; /* prevent it from getting too small */
+            max-width: 130px; /* slightly narrower to fit menu icon */
             padding: .3rem;
+        }
+
+        /* Menu button and dropdown */
+        .menu-wrapper {
+            position: relative;
+            flex-shrink: 0;
+        }
+
+        .menu-button {
+            width: 28px;
+            height: 28px;
+            display: flex;
+            align-items: center;
+            justify-content: center;
+            font-size: 1rem;
+            background: linear-gradient(to bottom, rgba(0,0,0,0.01), rgba(0,0,0,0.1));
+            border: 1px solid var(--color-panel-border);
+            border-radius: 8px;
+            -webkit-backdrop-filter: blur(4px) saturate(110%);
+            backdrop-filter: blur(4px) saturate(110%);
+            box-shadow: inset 0 1px 1px rgba(255,255,255,0.05);
+            color: var(--color-text-secondary);
+            cursor: pointer;
+            transition: all 0.2s ease;
+        }
+
+        .menu-button:hover {
+            color: var(--color-text-primary);
+            background: var(--color-panel-bg);
+        }
+
+        .menu-dropdown {
+            position: absolute;
+            top: calc(100% + 0.25rem);
+            left: 0;
+            display: flex;
+            flex-direction: column;
+            background: var(--color-panel-bg);
+            border: 1px solid var(--color-panel-border);
+            border-radius: 8px;
+            z-index: 20;
+            min-width: 140px;
+        }
+
+        .menu-dropdown a {
+            padding: 0.4rem 0.8rem;
+            color: var(--color-text-secondary);
+            text-decoration: none;
+            font-size: 0.8rem;
+            white-space: nowrap;
+        }
+
+        .menu-dropdown a:hover {
+            color: var(--color-text-primary);
+            background: var(--color-panel-bg);
         }
         /* Replace existing #usernameInput block with this */
 #usernameInput {


### PR DESCRIPTION
## Summary
- add compact hamburger menu in header with links to Home, Rosters, Ownership and placeholders
- shrink username field and style new menu button/dropdown for mobile
- wire up menu toggle behavior in shared app script

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b1cc9d0b64832e8c9279fb809bd4f8